### PR TITLE
Fix #11 end value overflow when greater than 999

### DIFF
--- a/src/app/countup/countup.directive.ts
+++ b/src/app/countup/countup.directive.ts
@@ -98,7 +98,7 @@ export class CountUpDirective implements AfterViewInit {
     const up = (end > sta) ? 1 : -1;
     // make easing smoother for large numbers
     if (diff > 999) {
-      countUp = new CountUp(this.el.nativeElement, sta, end + (up * 100), dec, dur / 2, this.options);
+      countUp = new CountUp(this.el.nativeElement, sta, end - (up * 100), dec, dur / 2, this.options);
     }
 
     return countUp;


### PR DESCRIPTION
This fixes the handling of end values greater than 999 to prevent exceeding it.

Please provide me with your feedback on improving this pull request since I am not entirely sure it does not break any other behavior of the directive.

But looked good after I tested 👍 

Related issues #11 , #9 

Thanks @inorganik .