### PR TITLE
Animation autoStart

### DIFF
--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -23,6 +23,8 @@ export class CountUpDirective implements OnChanges, AfterViewInit {
   // when endVal is changed
   previousEndVal: number;
 
+  @Input() autoStart: boolean;
+  // When endVal is exist, and autoStart is true, the countUp works (In ngAfterViewInit)
   @Input() options: CountUpOptions = {};
   @Input() reanimateOnClick = true;
   @Output() complete = new EventEmitter<void>();
@@ -38,7 +40,7 @@ export class CountUpDirective implements OnChanges, AfterViewInit {
   constructor(private el: ElementRef) {}
 
   ngAfterViewInit() {
-    if (this.endVal) {
+    if (this.endVal && this.autoStart) {
       this.countUp = new CountUp(this.el.nativeElement, this.endVal, this.options);
       this.animate();
       this.previousEndVal = this.endVal;

--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -6,14 +6,15 @@ import {
   HostListener,
   EventEmitter,
   OnChanges,
-  SimpleChanges
+  SimpleChanges,
+  AfterViewInit,
 } from '@angular/core';
 import { CountUp, CountUpOptions } from 'countup.js';
 
 @Directive({
   selector: '[countUp]'
 })
-export class CountUpDirective implements OnChanges {
+export class CountUpDirective implements OnChanges, AfterViewInit {
 
   countUp: CountUp;
   // the value you want to count to
@@ -36,6 +37,14 @@ export class CountUpDirective implements OnChanges {
 
   constructor(private el: ElementRef) {}
 
+  ngAfterViewInit() {
+    if (this.endVal) {
+      this.countUp = new CountUp(this.el.nativeElement, this.endVal, this.options);
+      this.animate();
+      this.previousEndVal = this.endVal;
+    }
+  }
+
   ngOnChanges(changes: SimpleChanges) {
     if (changes.endVal && !changes.endVal.firstChange) {
       if (this.previousEndVal != undefined) {
@@ -44,7 +53,7 @@ export class CountUpDirective implements OnChanges {
           startVal: this.previousEndVal
         };
       }
-      this.countUp = new CountUp(this.el.nativeElement, this.endVal,this.options);
+      this.countUp = new CountUp(this.el.nativeElement, this.endVal, this.options);
       this.animate();
       this.previousEndVal = this.endVal;
     }

--- a/projects/count-up/src/lib/count-up.directive.ts
+++ b/projects/count-up/src/lib/count-up.directive.ts
@@ -23,7 +23,8 @@ export class CountUpDirective implements OnChanges, AfterViewInit {
   // when endVal is changed
   previousEndVal: number;
 
-  @Input() autoStart: boolean;
+  @Input() autoStart = false;
+  // Default false
   // When endVal is exist, and autoStart is true, the countUp works (In ngAfterViewInit)
   @Input() options: CountUpOptions = {};
   @Input() reanimateOnClick = true;


### PR DESCRIPTION
Someone need animation autoStart (me). 
(When endVal has default value)
So, I made autoStart logic.



The autoStart feature is very simple

when user add 
```html
<span [countUp]="500">0</span>
```
In this case, countUp is exist first.
But this is not gonna work. 
7.1.0 version works compared to prev endVal and curr endVal

So, I thought first start animation will be need. (maybe not)

I made autoStart logic

```typescript
ngAfterViewInit() {
                                 // Added @Input() property, default value is false
    if (this.endVal && this.autoStart) {
      this.countUp = new CountUp(this.el.nativeElement, this.endVal, this.options);
      this.animate();
      this.previousEndVal = this.endVal;
    }
  }
```

I hope this pull request merge


